### PR TITLE
Better handling of non-zero offsets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "mc_schem"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc_schem"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 authors = ["Joseph <tokinobug@163.com>"]
 rust-version = "1.75"

--- a/src/schem/mod.rs
+++ b/src/schem/mod.rs
@@ -485,13 +485,23 @@ impl Schematic {
 
     /// The enclosing shape(xyz) of schematic
     pub fn shape(&self) -> [i32; 3] {
-        let mut result = [0, 0, 0];
-        for reg in &self.regions {
-            for dim in 0..3 {
-                result[dim] = max(result[dim], reg.offset[dim] + reg.shape()[dim]);
-            }
+        if self.regions.is_empty() {
+            [0, 0, 0]
+        } else {
+            std::array::from_fn(|dim| {
+                self.regions
+                    .iter()
+                    .map(|reg| reg.offset[dim] + reg.shape()[dim])
+                    .max()
+                    .unwrap()
+                    - self
+                        .regions
+                        .iter()
+                        .map(|reg| reg.offset[dim])
+                        .min()
+                        .unwrap()
+            })
         }
-        return result;
     }
 
     /// The volume of whole schematic

--- a/src/schem/world_edit13.rs
+++ b/src/schem/world_edit13.rs
@@ -555,8 +555,7 @@ impl Schematic {
                 for x in 0..shape[0] {
                     let mut cur_block_gindex: Option<u16> = None;
                     for (reg_idx, reg) in self.regions.iter().enumerate() {
-                        let offset = reg.offset;
-                        match reg.block_index_at([x - offset[0], y - offset[1], z - offset[2]]) {
+                        match reg.block_index_at([x, y, z]) {
                             Some(cur_idx) => {
                                 cur_block_gindex = Some(luts_of_block_idx[reg_idx][cur_idx as usize] as u16);
                                 break;


### PR DESCRIPTION
I was trying to create a worldedit schematic using this library. I created a region, gave it an offset, put it in a schematic, and saved it. All seemed fine until I put negative values in the offset, at which point the schematic was empty after conversion to nbt.

I looked into it and found some issues with how offsets are handled when non-zero. I've put some fixes in which solve the problems at least in the case of 1 region. With multiple regions I think there are still issues to be solved.

I can look into making multiple regions with offsets more robust if you'd like some more help with it?